### PR TITLE
uninitialized constant Gem error when doing commits

### DIFF
--- a/lib/githooks/commit-msg
+++ b/lib/githooks/commit-msg
@@ -24,6 +24,7 @@
 # cd your_project
 #  ~/.githooks/commit-msg .git/hooks
 
+require 'rubygems'
 require 'yaml'
 
 # Custom method to check for installed redmine_stagecoach gem


### PR DESCRIPTION
I found that your awesome commit hook approach wouldn't work when rubygems are not loaded
thus it throws

```
.git/hooks/commit-msg:33:in `gem_available?': uninitialized constant Gem (NameError)
    from .git/hooks/commit-msg:39
```
